### PR TITLE
Add django 1.11 scheme

### DIFF
--- a/django_configglue/schema.py
+++ b/django_configglue/schema.py
@@ -1111,7 +1111,7 @@ class Django13Schema(Django13Base):
         ###########
 
         logging_config = StringOption(null=True,
-            default='django.utils.log.dictConfig',
+            default='logging.config.dictConfig',
             help='The callable to use to configure logging')
         logging = DictOption(
             spec={
@@ -2034,6 +2034,17 @@ class Django18Schema(Django18Base):
             help="The name of the class to use for starting the test suite.")
 
 
+class Django111Schema(Django18Base):
+    version = '1.11'
+
+    # sections
+    class django(Django18Base.django):
+
+        logging_config = StringOption(null=True,
+            default='logging.config.dictConfig',
+            help='The callable to use to configure logging')
+
+
 class DjangoSchemaFactory(object):
     def __init__(self):
         self._schemas = {}
@@ -2256,3 +2267,6 @@ schemas.register(Django18Schema, '1.8.16')
 schemas.register(Django18Schema, '1.8.17')
 schemas.register(Django18Schema, '1.8.18')
 schemas.register(Django18Schema, '1.8.19')
+
+schemas.register(Django111Schema)
+schemas.register(Django18Schema, '1..19')

--- a/django_configglue/schema.py
+++ b/django_configglue/schema.py
@@ -2019,26 +2019,40 @@ class Django18Schema(Django18Base):
             default=True,
             help="If True, the SecurityMiddleware redirects all non-HTTPS requests to HTTPS (except for those URLs matching a regular expression listed in SECURE_REDIRECT_EXEMPT).")
 
-        templates = ListOption(
-            item=UpperCaseDictOption(spec={
-                'backend': StringOption(),
-                'name': StringOption(),
-                'dirs': ListOption(item=StringOption(), default=[]),
-                'app_dirs': BoolOption(default=False),
-                'options': DictOption(),
+        templates = ListOption(item=UpperCaseDictOption(spec={
+            'backend': StringOption(default='django.template.backends.django.DjangoTemplates'),
+            'dirs': ListOption(item=StringOption(), default=[]),
+            'app_dirs': BoolOption(default=False),
+            'options': DictOption(spec={
+                'context_processors': ListOption(item=StringOption()),
+                'loaders': ListOption(item=StringOption(), default=[
+                    'django.template.loaders.filesystem.Loader',
+                    'django.template.loaders.app_directories.Loader'
+                ]),
             }),
-            default=[])
+
+        }, default={}), default=[])
 
         test_runner = StringOption(
             default='django.test.runner.DiscoverRunner',
             help="The name of the class to use for starting the test suite.")
 
 
-class Django111Schema(Django18Base):
+Django111Base = derivate_django_schema(
+    Django18Schema,
+    exclude=[
+        'template_loaders',
+        'template_context_processors',
+        'template_debug',
+        'template_dirs'
+    ])
+
+
+class Django111Schema(Django111Base):
     version = '1.11'
 
     # sections
-    class django(Django18Base.django):
+    class django(Django111Base.django):
 
         logging_config = StringOption(null=True,
             default='logging.config.dictConfig',
@@ -2269,4 +2283,4 @@ schemas.register(Django18Schema, '1.8.18')
 schemas.register(Django18Schema, '1.8.19')
 
 schemas.register(Django111Schema)
-schemas.register(Django18Schema, '1..19')
+schemas.register(Django111Schema, '1.11.26')

--- a/django_configglue/tests/test_configglue.py
+++ b/django_configglue/tests/test_configglue.py
@@ -292,7 +292,7 @@ class DjangoSupportTestCase(SchemaHelperTestCase):
         schema = schemas.get('1.3')
         section = Section(name='django')
         expected = StringOption(name='logging_config', null=True,
-            default='django.utils.log.dictConfig',
+            default='logging.config.dictConfig',
             help='The callable to use to configure logging')
         expected.section = section
         self.assertEqual(schema.django.logging_config, expected)


### PR DESCRIPTION
## Reason of the change

I'm upgrading muladmin to be compatible with the latest django version (`1.11.26`) for python2.7. This code was necessary to make it work. Changes should not affect any previous schema version functioning.

## Scope of changes.
* Django 1.11 uses new style `settings.TEMPLATES` template configuration. `TEMPLATE_DEBUG`, 
`TEMPLATE_DIRS`, `TEMPLATE_LOADERS` settings are no more valid.
* `django.utils.log.dictConfig` was removed from django codebase. (https://docs.djangoproject.com/en/dev/internals/deprecation/#deprecation-removed-in-1-9)

## Testing

This is how i tested the results of these changes in muladmin.

`echo 'from django.conf import settings; import json; print(json.dumps(settings.TEMPLATES, indent=4))' | ./manage.py shell`

The output (properly configured django template settings).

```
[
    {
        "DIRS": [], 
        "APP_DIRS": false, 
        "OPTIONS": {
            "context_processors": [
                "django.core.context_processors.debug", 
                "django.core.context_processors.i18n", 
                "django.core.context_processors.media", 
                "django.core.context_processors.request", 
                "django.core.context_processors.static", 
                "prezi.website.i18n.context_processors.language_api_context_processor", 
                "prezi.website.common.context_processors.environment", 
                "prezi.website.common.context_processors.settings", 
                "prezi.website.common.context_processors.lang_context_processor", 
                "prezi.website.common.context_processors.product_types"
            ], 
            "loaders": [
                "django.template.loaders.filesystem.Loader", 
                "django.template.loaders.app_directories.Loader", 
                "django.template.loaders.eggs.Loader"
            ]
        }, 
        "BACKEND": "django.template.backends.django.DjangoTemplates"
    }
]
```